### PR TITLE
feat: Create initial Flutter application scaffold

### DIFF
--- a/mobile_app/lib/db/app_db.dart
+++ b/mobile_app/lib/db/app_db.dart
@@ -1,0 +1,13 @@
+// WHY: This file is a stub for the database logic.
+// Creating a stub now allows the rest of the app to be built
+// without a fully implemented database, making development faster.
+// The real implementation will use sqflite to persist data locally.
+
+class AppDb {
+  // A stub function for initializing the database.
+  // The actual implementation will open the database and create tables.
+  Future<void> initDb() async {
+    // In the future, this will initialize the sqflite database.
+    print("Database initialization stub.");
+  }
+}

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1,0 +1,68 @@
+// WHY: This is the main entry point of the application. It sets up the
+// MaterialApp, defines the navigation routes, and specifies the initial
+// screen. This structure allows for a clean separation of concerns and
+// scalable navigation.
+
+import 'package:flutter/material.dart';
+import 'package:mobile_app/ui/budget_dashboard_page.dart';
+import 'package:mobile_app/ui/capture_receipt_page.dart';
+import 'package:mobile_app/ui/manual_entry_page.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Xubudget',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+        visualDensity: VisualDensity.adaptivePlatformDensity,
+      ),
+      // Defining the routes for navigation
+      initialRoute: BudgetDashboardPage.routeName,
+      routes: {
+        BudgetDashboardPage.routeName: (context) => const BudgetDashboardPageWithNav(),
+        CaptureReceiptPage.routeName: (context) => const CaptureReceiptPage(),
+        ManualEntryPage.routeName: (context) => const ManualEntryPage(),
+      },
+    );
+  }
+}
+
+// WHY: A wrapper for the dashboard to include navigation buttons, keeping the
+// core dashboard view separate from its navigation controls.
+class BudgetDashboardPageWithNav extends StatelessWidget {
+  const BudgetDashboardPageWithNav({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      // The actual dashboard UI is composed here.
+      // We reuse the BudgetDashboardPage and add navigation controls.
+      body: const BudgetDashboardPage(),
+      floatingActionButton: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          FloatingActionButton.extended(
+            onPressed: () => Navigator.pushNamed(context, CaptureReceiptPage.routeName),
+            label: const Text("OCR"),
+            icon: const Icon(Icons.camera_alt),
+            heroTag: 'ocr_fab', // Prevents hero animation conflicts
+          ),
+          const SizedBox(height: 10),
+          FloatingActionButton.extended(
+            onPressed: () => Navigator.pushNamed(context, ManualEntryPage.routeName),
+            label: const Text("Manual"),
+            icon: const Icon(Icons.edit),
+            heroTag: 'manual_fab', // Prevents hero animation conflicts
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/models/expense.dart
+++ b/mobile_app/lib/models/expense.dart
@@ -1,0 +1,17 @@
+// WHY: This file defines the core data model for an expense.
+// Keeping it in a separate `models` directory helps organize the data
+// structure of the application and decouples it from the UI or business logic.
+
+class Expense {
+  final int? id;
+  final String description;
+  final double amount;
+  final DateTime date;
+
+  Expense({
+    this.id,
+    required this.description,
+    required this.amount,
+    required this.date,
+  });
+}

--- a/mobile_app/lib/ui/budget_dashboard_page.dart
+++ b/mobile_app/lib/ui/budget_dashboard_page.dart
@@ -1,0 +1,32 @@
+// WHY: This is the main dashboard screen. It will display a summary of the
+// budget and provide navigation to other features. For this scaffold, it
+// contains only a dummy total.
+
+import 'package:flutter/material.dart';
+
+class BudgetDashboardPage extends StatelessWidget {
+  const BudgetDashboardPage({super.key});
+
+  static const String routeName = '/';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text('Total de despesas (dummy):'),
+            Text(
+              'R\$ 1,234.56',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/ui/capture_receipt_page.dart
+++ b/mobile_app/lib/ui/capture_receipt_page.dart
@@ -1,0 +1,22 @@
+// WHY: This screen will handle capturing receipts using the camera or gallery
+// and processing them with OCR. For the scaffold, it's a simple placeholder.
+
+import 'package:flutter/material.dart';
+
+class CaptureReceiptPage extends StatelessWidget {
+  const CaptureReceiptPage({super.key});
+
+  static const String routeName = '/capture';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Capturar Recibo (OCR)'),
+      ),
+      body: const Center(
+        child: Text('Placeholder para a captura de recibo.'),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/ui/manual_entry_page.dart
+++ b/mobile_app/lib/ui/manual_entry_page.dart
@@ -1,0 +1,22 @@
+// WHY: This screen provides a form for users to manually enter expense
+// details. For the scaffold, it is just a placeholder.
+
+import 'package:flutter/material.dart';
+
+class ManualEntryPage extends StatelessWidget {
+  const ManualEntryPage({super.key});
+
+  static const String routeName = '/manual';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Entrada Manual'),
+      ),
+      body: const Center(
+        child: Text('Placeholder para a entrada manual de despesa.'),
+      ),
+    );
+  }
+}

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,0 +1,36 @@
+# WHY: This file defines the Flutter project's dependencies and metadata,
+# as required by the issue. It includes packages for state management (Riverpod),
+# local ML services (ML Kit, Speech to Text), database, and utilities.
+
+name: mobile_app
+description: "A new Flutter project for Xubudget."
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  # Core dependencies as per issue spec
+  flutter_riverpod: ^2.5.1
+  google_mlkit_text_recognition: ^0.11.0
+  image_picker: ^1.0.7
+  speech_to_text: ^6.6.0
+  sqflite: ^2.3.2
+  path_provider: ^2.1.2
+  intl: ^0.19.0
+
+  # Default Flutter icons
+  cupertino_icons: ^1.0.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
This commit introduces the basic structure for the Xubudget mobile application as per the issue requirements.

It includes:
- A `pubspec.yaml` file with all the specified dependencies.
- Three placeholder screens: Dashboard, Capture Receipt (OCR), and Manual Entry.
- A `main.dart` file that sets up the MaterialApp and defines the routes for navigation between the screens.
- A simple `Expense` data model.
- A stub for the `AppDb` database class.
- Placeholder directories for `android`, `ios`, `web`, and `test` to ensure a standard project structure.

All created files include a `WHY:` comment at the top explaining their purpose.