### PR TITLE
docs: add initial issue templates

### DIFF
--- a/docs/issues/issue2_services_locais.md
+++ b/docs/issues/issue2_services_locais.md
@@ -1,0 +1,22 @@
+# [Services] OCR, Speech e Parser PT-BR integrados ao UI
+
+**Objetivo**
+Implementar serviços locais (Dart) e conectar às telas.
+
+**Arquivos**
+1) mobile_app/lib/services/ocr_service.dart        (MLKit: extrair texto de imagem local)
+2) mobile_app/lib/services/voice_service.dart      (speech_to_text: iniciar/parar + transcrição)
+3) mobile_app/lib/services/expense_parser.dart     (regex PT-BR: "comprei X por 12,34 no dia Y" -> {description, amount, date, category?})
+4) mobile_app/lib/ui/capture_receipt_page.dart     (ATUALIZAR p/ chamar ocr_service e exibir texto)
+5) mobile_app/lib/ui/manual_entry_page.dart        (ATUALIZAR p/ usar expense_parser)
+
+**Regras**
+- `WHY:` no topo de cada arquivo.
+- Sem dependências novas além das já no pubspec.
+- Nada de rede/http; tudo local.
+- Somente os arquivos listados.
+
+**Pronto quando**
+- OCR retorna texto básico de imagem local.
+- Speech transcreve frases curtas.
+- Parser extrai amount/date/descrição em exemplos simples.

--- a/docs/issues/issue3_backend_llm.md
+++ b/docs/issues/issue3_backend_llm.md
@@ -1,0 +1,19 @@
+# [Backend] Categorizer com LLM local (Ollama + Qwen2.5-1.5B) + client Dart
+
+**Objetivo**
+Trocar heurística por LLM leve e local via Ollama, com fallback por regex. Atualizar client Dart.
+
+**Arquivos**
+1) services/pi2_assistant/requirements.txt  (+requests)
+2) services/pi2_assistant/pi2_server.py     (POST /categorize usa Ollama http://127.0.0.1:11434 com model "qwen2.5:1.5b-instruct"; fallback regex; GET /healthz)
+3) mobile_app/lib/services/categorizer_service.dart (client http p/ chamar /categorize)
+
+**Regras**
+- `WHY:` no topo dos 3 arquivos.
+- Não baixar modelo no repositório; documentar no PR como instalar Ollama e executar `ollama pull qwen2.5:1.5b-instruct`.
+- Timeout baixo e temperatura baixa (0.1). Se o LLM não responder, usar fallback regex.
+- Apenas os arquivos listados.
+
+**Pronto quando**
+- `uvicorn ...:5001` responde `/healthz`.
+- POST `/categorize` retorna categoria coerente para 3 exemplos do PR (alimentacao/transporte/saude).

--- a/docs/issues/issue4_exportacao.md
+++ b/docs/issues/issue4_exportacao.md
@@ -1,0 +1,17 @@
+# [Export] CSV/XLSX em data/exports + botão "Exportar agora"
+
+**Objetivo**
+Gerar export local CSV e XLSX para `data/exports/` com timestamp e acionar via botão no Dashboard.
+
+**Arquivos**
+1) mobile_app/lib/services/export_service.dart  (gera CSV/XLSX; cria pasta; usar `intl`)
+2) mobile_app/lib/ui/budget_dashboard_page.dart (ATUALIZAR: botão "Exportar agora" -> chama export_service)
+3) docs/export_readme.md                        (onde ficam arquivos, timezone, convenção de nome; caminho típico Windows)
+
+**Regras**
+- `WHY:` no topo de cada arquivo.
+- Evitar hardcode de caminho; preferir `path_provider` + doc ensinando ajustar p/ `C:\\Users\\marco\\Xubudget\\data\\exports\\`
+- Sem libs novas além de `csv`/`excel` (já no scaffold).
+
+**Pronto quando**
+- Ao clicar o botão, aparecem `.csv` e `.xlsx` em `data/exports/` com carimbo data/hora.

--- a/docs/issues/issue_fix_scaffold_flutter_create.md
+++ b/docs/issues/issue_fix_scaffold_flutter_create.md
@@ -1,0 +1,17 @@
+# [Fix] Completar scaffold Flutter com `flutter create` em mobile_app/
+
+**Problema**
+O scaffold atual não tem os diretórios de plataforma preenchidos. Pastas vazias não entram no git e o app não roda com `flutter run`.
+
+**Tarefa**
+- Executar `flutter create .` dentro de `mobile_app/` (ou recriar exatamente os arquivos padrão gerados pelo Flutter).
+- Committar **todos** os arquivos de `android/`, `ios/`, `web/`, `test/`, `.metadata`, `.gitignore` específicos etc.
+- Manter `pubspec.yaml` e `lib/` que já foram criados no PR anterior.
+
+**Regras**
+- Não alterar nomes de pacotes ou imports existentes.
+- No topo do PR, explicar o que foi adicionado.
+- Garantir que `flutter pub get` e `flutter analyze` passem.
+
+**Aceite**
+- `flutter run` compila e abre a `BudgetDashboardPage`.


### PR DESCRIPTION
## Summary
- add scaffold fix issue template
- add service integration issue template
- add backend LLM issue template
- add export feature issue template

## Testing
- `gh issue create --title "[Fix] Completar scaffold Flutter com flutter create em mobile_app/" --label jules --body-file "docs/issues/issue_fix_scaffold_flutter_create.md"` *(fails: gh auth login required)*
- `gh issue create --title "[Services] OCR, Speech e Parser PT-BR integrados ao UI" --label jules --body-file "docs/issues/issue2_services_locais.md"` *(fails: gh auth login required)*
- `gh issue create --title "[Backend] Categorizer com LLM local (Ollama + Qwen2.5-1.5B) + client Dart" --label jules --body-file "docs/issues/issue3_backend_llm.md"` *(fails: gh auth login required)*
- `gh issue create --title "[Export] CSV/XLSX em data/exports + botão 'Exportar agora'" --label jules --body-file "docs/issues/issue4_exportacao.md"` *(fails: gh auth login required)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb961d6ae483308cd6fa38846e32b8